### PR TITLE
Update checks to avoid errors in logs (http.error)

### DIFF
--- a/core/class/philipsHue.class.php
+++ b/core/class/philipsHue.class.php
@@ -872,25 +872,25 @@ class philipsHue extends eqLogic {
 			if (isset($data['enabled'])) {
 				$eqLogic->checkAndUpdateCmd('enabled', $data['enabled']);
 			}
-			if (isset($data['motion'])) {
+			if (isset($data['motion']['motion'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'], $data['motion']['motion']);
 			}
-			if (isset($data['light'])) {
+			if (isset($data['light']['light_level'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'], $data['light']['light_level']);
 			}
-			if (isset($data['temperature'])) {
+			if (isset($data['temperature']['temperature'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'], $data['temperature']['temperature']);
 			}
-			if (isset($data['button']) && isset($data['button']['last_event'])) {
+			if (isset($data['button']['last_event'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'], $data['button']['last_event']);
 			}
-			if (isset($data['contact_report'])) {
+			if (isset($data['contact_report']['state'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'],  ($data['contact_report']['state'] == 'contact'));
 			}
-			if (isset($data['tamper_reports'])) {
+			if (isset($data['tamper_reports']['state'])) {
 				$eqLogic->checkAndUpdateCmd($data['id'], ($data['tamper_reports']['state'] == 'tampered'));
 			}
-			if (isset($data['relative_rotary'])) {
+			if (isset($data['relative_rotary']['last_event']['rotation']['direction']) && isset($data['relative_rotary']['last_event']['rotation']['steps'])) {
 				$direction = ($data['relative_rotary']['last_event']['rotation']['direction'] == 'counter_clock_wise') ? 1 : - 1;
 				$eqLogic->checkAndUpdateCmd($data['id'], $direction * $data['relative_rotary']['last_event']['rotation']['steps']);
 			}


### PR DESCRIPTION
Update $data['xxx'] checks to avoid php notice in http.error if item is not available

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
J'ai régulièrement ces message d'erreur dans le plugin, dans les logs http.error : 

0000|[Sat Nov 29 16:12:08.398705 2025] [php7:notice] [pid 623706:tid 623706] [client 127.0.0.1:44192] PHP Notice: Undefined index: motion in /var/www/html/plugins/philipsHue/core/class/philipsHue.class.php on line 876
0001|[Sat Nov 29 16:12:13.373246 2025] [php7:notice] [pid 710554:tid 710554] [client 127.0.0.1:50512] PHP Notice: Undefined index: light_level in /var/www/html/plugins/philipsHue/core/class/philipsHue.class.php on line 879
0002|[Sat Nov 29 16:12:22.490977 2025] [php7:notice] [pid 623706:tid 623706] [client 127.0.0.1:54758] PHP Notice: Undefined index: motion in /var/www/html/plugins/philipsHue/core/class/philipsHue.class.php on line 876

Jeedom : 4.5 (Stable)
Plugin PhilipsHue : Stable

### Suggested changelog entry
Ajout d'une vérification de l'existence des entrées dans le tableau $data avant d'utiliser la valeur associée

<!-- Please provide a short description of the change for the changelog. -->


### Related issues/external references

Fixes #
Fixe les messages d'erreurs dans les logs http.error si le champ correspondant n'existe pas

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
